### PR TITLE
fix: remove delete action from poster completed tasks

### DIFF
--- a/src/features/tasks/screens/mytasks/components/TaskCard.tsx
+++ b/src/features/tasks/screens/mytasks/components/TaskCard.tsx
@@ -1460,7 +1460,7 @@ export default function TaskCard({ task, onPress, status, userRole, onTaskCancel
             </TouchableOpacity>
           </>
         ) : status === 'completed' && userRole === 'Poster' ? (
-          // Completed tab (Poster): View Receipt + Delete button only (no Rate & Review button)
+          // Completed tab (Poster): View Receipt button only (no Delete button, no Rate & Review button)
           // Rating happens through completion flow popup, not from completed tab
           <>
             <TouchableOpacity 
@@ -1478,23 +1478,6 @@ export default function TaskCard({ task, onPress, status, userRole, onTaskCancel
                 name="receipt" 
                 size={20} 
                 color={isProcessing ? "#999" : "#007AFF"} 
-              />
-            </TouchableOpacity>
-            <TouchableOpacity 
-              style={[
-                styles.actionButton, 
-                styles.deleteButton, 
-                (deleteTaskMutation.isPending || isProcessing) && styles.disabledButton
-              ]} 
-              activeOpacity={0.6}
-              hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
-              onPress={handleDeleteTask}
-              disabled={deleteTaskMutation.isPending || isProcessing}
-            >
-              <MaterialIcons 
-                name="delete" 
-                size={20} 
-                color={(deleteTaskMutation.isPending || isProcessing) ? "#999" : "#dc3545"} 
               />
             </TouchableOpacity>
           </>


### PR DESCRIPTION
Removed the Delete button from task cards in the Poster role’s Completed tab.

- Kept the View Receipt button fully functional.
- Updated inline comments to reflect the new behavior.
- No changes to other tabs or roles.

Result: Poster completed tasks now show only the View Receipt action, as intended.