### PR TITLE
fix: browse filters reset, dynamic price range, and filter count

### DIFF
--- a/src/features/tasks/screens/browse/browse-screen.tsx
+++ b/src/features/tasks/screens/browse/browse-screen.tsx
@@ -3,12 +3,12 @@ import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ActivityIndicator,
-  FlatList,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View
+    ActivityIndicator,
+    FlatList,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View
 } from 'react-native';
 
 // API and Hooks
@@ -20,13 +20,13 @@ import NotificationModal from '@/src/features/messages/screens/notification-scre
 import { TaskCard } from '@/src/features/tasks/components';
 import { useUnreadCount } from '@/src/shared/hooks/useNotifications';
 import {
-  FilterButton,
-  FilterModal,
-  MapView,
-  SearchBar,
-  SortButton,
-  SortModal,
-  ViewModeToggle
+    FilterButton,
+    FilterModal,
+    MapView,
+    SearchBar,
+    SortButton,
+    SortModal,
+    ViewModeToggle
 } from './components';
 
 // Network components
@@ -325,7 +325,7 @@ export default function BrowseTasksScreen() {
       {/* Filter & Sort Row */}
       <View style={styles.filterSortRow}>
         <FilterButton 
-          activeFiltersCount={activeFiltersCount}
+          filteredTasksCount={filteredAndSortedTasks.length}
           onPress={() => setFilterVisible(true)}
         />
         <SortButton onPress={() => setSortVisible(true)} />

--- a/src/features/tasks/screens/browse/components/FilterButton.tsx
+++ b/src/features/tasks/screens/browse/components/FilterButton.tsx
@@ -1,18 +1,17 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import React from 'react';
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 
 interface FilterButtonProps {
-  activeFiltersCount: number;
+  filteredTasksCount: number;
   onPress: () => void;
 }
 
-export default function FilterButton({ activeFiltersCount, onPress }: FilterButtonProps) {
+export default function FilterButton({ filteredTasksCount, onPress }: FilterButtonProps) {
   return (
     <TouchableOpacity style={styles.filterBtn} onPress={onPress}>
       <MaterialCommunityIcons name="filter-variant" size={20} />
       <Text style={styles.filterText}>
-        Filter {activeFiltersCount > 0 && `(${activeFiltersCount})`}
+        Filter ({filteredTasksCount})
       </Text>
     </TouchableOpacity>
   );

--- a/src/features/tasks/screens/browse/components/FilterModal.tsx
+++ b/src/features/tasks/screens/browse/components/FilterModal.tsx
@@ -1,7 +1,7 @@
 import { useLocationCountry } from '@/src/shared/hooks/useLocationCountry';
-import { getCurrencySymbol } from '@/src/shared/utils/currency';
+import { getCurrencySymbol, getMaxPriceForCurrency } from '@/src/shared/utils/currency';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Modal,
   PanResponder,
@@ -61,7 +61,8 @@ export default function FilterModal({
   const [activeThumb, setActiveThumb] = useState<'min' | 'max' | null>(null);
 
   const MIN_PRICE = 0;
-  const MAX_PRICE = 10000;
+  // Dynamic MAX_PRICE based on user's currency (e.g., 10000 for AUD, 3000000 for LKR)
+  const MAX_PRICE = getMaxPriceForCurrency(countryInfo.currency);
 
   // Filter categories based on search text with prioritized sorting
   const filteredCategories = useMemo(() => {
@@ -322,7 +323,7 @@ export default function FilterModal({
               </View>
               <View style={styles.sliderLabels}>
                 <Text style={styles.sliderLabel}>{currencySymbol}0</Text>
-                <Text style={styles.sliderLabel}>{currencySymbol}10,000+</Text>
+                <Text style={styles.sliderLabel}>{currencySymbol}{MAX_PRICE.toLocaleString()}+</Text>
               </View>
             </View>
           </View>

--- a/src/features/tasks/screens/browse/hooks/useBrowseFiltersAPI.ts
+++ b/src/features/tasks/screens/browse/hooks/useBrowseFiltersAPI.ts
@@ -2,6 +2,7 @@
 import { Task, TaskFilterParams, TaskSearchParams } from '@/src/api/types/tasks';
 import { useLocationCountry } from '@/src/shared/hooks/useLocationCountry';
 import { useFilterTasks, useSearchTasks } from '@/src/shared/hooks/useTaskApi';
+import { getMaxPriceForCurrency } from '@/src/shared/utils/currency';
 import * as Location from 'expo-location';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -276,7 +277,13 @@ const FILTER_SORT_MAPPING = [
 export const useBrowseFiltersAPI = () => {
   const [selectedCategory, setSelectedCategory] = useState('All Categories');
   const [taskType, setTaskType] = useState<'all' | 'in-person' | 'remote'>('all');
-  const [priceRange, setPriceRange] = useState<[number, number]>([0, 10000]);
+  
+  // Get user's country from geo-location for filtering tasks
+  const { countryInfo, isDetecting: isDetectingCountry } = useLocationCountry();
+  
+  // Use dynamic max price based on user's currency
+  const MAX_PRICE = getMaxPriceForCurrency(countryInfo.currency);
+  const [priceRange, setPriceRange] = useState<[number, number]>([0, MAX_PRICE]);
   const [availableTasksOnly, setAvailableTasksOnly] = useState(false);
   const [showTasksWithNoOffers, setShowTasksWithNoOffers] = useState(false);
   const [selectedSort, setSelectedSort] = useState(0);
@@ -294,9 +301,6 @@ export const useBrowseFiltersAPI = () => {
   // Track the last processed page to prevent duplicate processing
   const lastProcessedPageRef = React.useRef<number>(0);
   const lastProcessedDataHashRef = React.useRef<string>('');
-
-  // Get user's country from geo-location for filtering tasks
-  const { countryInfo, isDetecting: isDetectingCountry } = useLocationCountry();
 
   // Log country detection status
   useEffect(() => {
@@ -700,22 +704,24 @@ export const useBrowseFiltersAPI = () => {
     let count = 0;
     if (selectedCategory !== 'All Categories') count++;
     if (taskType !== 'all') count++;
-    if (priceRange[0] !== 0 || priceRange[1] !== 10000) count++;
+    if (priceRange[0] !== 0 || priceRange[1] !== MAX_PRICE) count++;
     if (availableTasksOnly) count++;
     if (showTasksWithNoOffers) count++;
     return count;
   };
 
   const resetFilters = () => {
+    console.log('🔄 Resetting all filters to defaults (MAX_PRICE:', MAX_PRICE, ')');
     setSelectedCategory('All Categories');
     setTaskType('all');
-    setPriceRange([0, 10000]);
+    setPriceRange([0, MAX_PRICE]);
     setAvailableTasksOnly(false);
     setShowTasksWithNoOffers(false);
     setSelectedSort(0);
     setSearchText('');
     setCurrentPage(1);
-    setTasksWithOfferCounts([]);
+    // Don't clear tasks - let them reload from API with reset filters
+    // setTasksWithOfferCounts([]); // REMOVED: This was causing tasks to disappear
     setHasMore(true);
   };
 

--- a/src/shared/utils/currency.ts
+++ b/src/shared/utils/currency.ts
@@ -284,3 +284,46 @@ export const getMinimumBudget = (currencyCode: string): number => {
 export const getDefaultBudget = (currencyCode: string): number => {
   return getMinimumBudget(currencyCode);
 };
+
+/**
+ * Maximum price range amounts for different currencies
+ * Used for filter price range sliders
+ */
+const MAX_PRICE_MAP: Record<string, number> = {
+  'USD': 10000,
+  'AUD': 10000,    // $10,000 AUD
+  'NZD': 15000,    // $15,000 NZD
+  'LKR': 1000000,  // Rs 1,000,000 LKR
+  'SGD': 13500,    // $13,500 SGD
+  'MYR': 45000,    // RM 45,000 MYR
+  'IDR': 157500000, // Rp 157,500,000 IDR
+  'THB': 350000,   // ฿350,000 THB
+  'PHP': 550000,   // ₱550,000 PHP
+  'VND': 250000000, // ₫250,000,000 VND
+  'INR': 825000,   // ₹825,000 INR
+  'PKR': 2800000,  // ₨2,800,000 PKR
+  'BDT': 1100000,  // ৳1,100,000 BDT
+  'JPY': 1500000,  // ¥1,500,000 JPY
+  'CNY': 72500,    // ¥72,500 CNY
+  'KRW': 13500000, // ₩13,500,000 KRW
+  'HKD': 77500,    // $77,500 HKD
+  'CAD': 14000,    // $14,000 CAD
+  'MXN': 170000,   // $170,000 MXN
+  'BRL': 50000,    // R$50,000 BRL
+  'GBP': 8000,     // £8,000 GBP
+  'EUR': 9500,     // €9,500 EUR
+  'CHF': 9000,     // Fr 9,000 CHF
+  'SEK': 107500,   // 107,500 kr SEK
+  'NOK': 107500,   // 107,500 kr NOK
+  'DKK': 70000,    // 70,000 kr DKK
+  'ZAR': 185000,   // R185,000 ZAR
+};
+
+/**
+ * Get maximum price for filter range based on currency
+ * @param currencyCode - Currency code (e.g., 'USD', 'LKR', 'AUD')
+ * @returns Maximum price amount for the currency
+ */
+export const getMaxPriceForCurrency = (currencyCode: string): number => {
+  return MAX_PRICE_MAP[currencyCode] || 10000;
+};


### PR DESCRIPTION
Fixed Browse Tasks filter reset and improved filtering UX.

- Fixed resetFilters() to reset values without clearing task list.
- Tasks now stay visible and re-fetch correctly after reset.
- Implemented country-based dynamic max price ranges.
- Updated filter button to show filtered task count instead of active filters.

Result: Reset works reliably, price ranges match user currency, and filter count reflects actual results.