### PR TITLE
fix: restrict offer status visibility

### DIFF
--- a/src/features/tasks/screens/browse/components/SortModal.tsx
+++ b/src/features/tasks/screens/browse/components/SortModal.tsx
@@ -43,7 +43,11 @@ export default function SortModal({
               <Ionicons name="close" size={24} color="#666" />
             </TouchableOpacity>
           </View>
-          <ScrollView>
+          <ScrollView 
+            style={styles.scrollView}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={true}
+          >
             {sortOptions.map((option, index) => (
               <TouchableOpacity
                 key={index}
@@ -87,6 +91,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     maxHeight: '70%',
+    paddingBottom: 20, // Add bottom padding to prevent content from being hidden by nav bar
   },
   sortHeader: {
     flexDirection: 'row',
@@ -99,6 +104,12 @@ const styles = StyleSheet.create({
   sortTitle: {
     fontSize: 18,
     fontWeight: '600',
+  },
+  scrollView: {
+    flexGrow: 0, // Prevent ScrollView from expanding beyond maxHeight
+  },
+  scrollContent: {
+    paddingBottom: 24, // Extra padding at bottom for better scrolling experience
   },
   sortOption: {
     flexDirection: 'row',

--- a/src/features/tasks/screens/detail/components/OffersList.tsx
+++ b/src/features/tasks/screens/detail/components/OffersList.tsx
@@ -121,7 +121,7 @@ export const OffersList: React.FC<OffersListProps> = ({
 };
 
 // Component to display offer amount and status
-const OfferAmountStatus: React.FC<{ offer: any; isTaskPoster: boolean }> = ({ offer, isTaskPoster }) => {
+const OfferAmountStatus: React.FC<{ offer: any; isTaskPoster: boolean; showStatus?: boolean }> = ({ offer, isTaskPoster, showStatus = true }) => {
   const { countryInfo } = useLocationCountry();
   const currencyInfo = getCurrencyFromUserLocation(countryInfo);
   
@@ -139,22 +139,25 @@ const OfferAmountStatus: React.FC<{ offer: any; isTaskPoster: boolean }> = ({ of
           </Text>
         </View>
       )}
-      <View style={[
-        styles.offerStatusBadge,
-        status === 'accepted' ? styles.acceptedStatusBadge : styles.pendingStatusBadge
-      ]}>
-        <Ionicons 
-          name={status === 'accepted' ? 'checkmark-circle' : 'time'} 
-          size={14} 
-          color={status === 'accepted' ? '#4CAF50' : '#FFA500'} 
-        />
-        <Text style={[
-          styles.offerStatusText,
-          status === 'accepted' ? styles.acceptedStatusText : styles.pendingStatusText
+      {/* Only show status badge if showStatus is true (hidden for other taskers' offers) */}
+      {showStatus && (
+        <View style={[
+          styles.offerStatusBadge,
+          status === 'accepted' ? styles.acceptedStatusBadge : styles.pendingStatusBadge
         ]}>
-          {status === 'accepted' ? 'Accepted' : 'Pending'}
-        </Text>
-      </View>
+          <Ionicons 
+            name={status === 'accepted' ? 'checkmark-circle' : 'time'} 
+            size={14} 
+            color={status === 'accepted' ? '#4CAF50' : '#FFA500'} 
+          />
+          <Text style={[
+            styles.offerStatusText,
+            status === 'accepted' ? styles.acceptedStatusText : styles.pendingStatusText
+          ]}>
+            {status === 'accepted' ? 'Accepted' : 'Pending'}
+          </Text>
+        </View>
+      )}
     </View>
   );
 };
@@ -304,8 +307,12 @@ const OfferCard: React.FC<OfferCardProps> = ({ offer, taskCreatorId, currentUser
                     )}
                   </View>
 
-                  {/* Offer Amount and Status - Only visible to task poster */}
-                  <OfferAmountStatus offer={offer} isTaskPoster={isTaskPoster || false} />
+                  {/* Offer Amount and Status - Hide status for other taskers viewing offers */}
+                  <OfferAmountStatus 
+                    offer={offer} 
+                    isTaskPoster={isTaskPoster || false} 
+                    showStatus={isTaskPoster || false}
+                  />
 
                   {/* Rating and Stats Row */}
                   <View style={styles.offerStatsRow}>


### PR DESCRIPTION
Fixed offer status visibility in the offers list.

- Added showStatus prop to OfferAmountStatus (default true).
- Display status badges only for the task poster.
- Hide Pending/Accepted status for other taskers viewing offers.
- Ensures posters see full offer context while taskers get a cleaner UI.

Improves clarity and prevents unnecessary status exposure.